### PR TITLE
增加配置组件标签代码风格的功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "component",
     "snippets"
   ],
-  "version": "1.0.2",
+  "version": "1.1.0",
   "icon": "asset/vue.png",
   "engines": {
     "vscode": "^1.46.0"
@@ -23,6 +23,7 @@
   ],
   "main": "./src/extension.js",
   "scripts": {
+    "build": "vsce package",
     "lint": "eslint .",
     "pretest": "npm run lint",
     "test": "node ./test/runTest.js"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,15 @@
       "type": "object",
       "title": "vue-component",
       "properties": {
+        "vueComponent.style": {
+          "type": "string",
+          "default": "kebab-case",
+          "description": "Component tag autocomplete code style",
+          "enum": [
+            "kebab-case",
+            "PascalCase"
+          ]
+        },
         "vueComponent.aliases": {
           "type": "object",
           "default": {

--- a/src/extension.js
+++ b/src/extension.js
@@ -149,12 +149,13 @@ async function activate (context) {
     const editor = window.activeTextEditor
     const document = editor.document
     const fileNamePascal = toPascalCase(fileName)
+    const tagName = vscode.workspace.getConfiguration('vueComponent').get('style') === 'kebab-case' ? toKebabCase(fileName) :toPascalCase(fileName)
     // 先在光标处插入组件代码
     const { props } = parseFile(file)
     let tabStop = 1
     const requiredPropsSnippetStr = Object.keys(props).filter(prop => props[prop].required)
       .reduce((accumulator, prop) => accumulator += ` :${toKebabCase(prop)}="$${tabStop++}"`, '')
-    const snippetString = `<${fileNamePascal}${requiredPropsSnippetStr}>$0</${fileNamePascal}>`;
+    const snippetString = `<${tagName}${requiredPropsSnippetStr}>$0</${tagName}>`;
     await editor.insertSnippet(new SnippetString(snippetString))
     const components = parseDocument(document).components
     if (!components[fileNamePascal]) { // 没有注册组件，需要添加对应import、components


### PR DESCRIPTION
原先只能生成`PascalCase`风格的组件标签。
现在增加了配置选项，可以指定如下风格：`kebab-case`（默认）或`PascalCase`