### PR TITLE
fix: `toPascalCase()` 无法正确处理 `foo-1` 的问题

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -59,7 +59,7 @@ function getRelativePath (from, to) {
 * @since 2020-07-06 19:38:35
 */
 function toPascalCase (str) {
-  return str.replace(/(^|-)([a-z])/g, (keb, s1, s2) => s2.toUpperCase())
+  return str.replace(/(^|-)(\w)/g, (keb, s1, s2) => s2.toUpperCase())
 }
 /**
 * 帕斯卡命名法转为短横线命名法


### PR DESCRIPTION
问题：`toPascalCase('foo-1')`期望得到`Foo1`，实际得到`Foo-1`